### PR TITLE
Add Python version classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,5 +23,7 @@ setup(
     zip_safe=False,
     classifiers=[
         'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ],
 )


### PR DESCRIPTION
This allows third parties to recognize that this package is Python3-ready.

Just noticed this in pyup, which thinks that this package is a blocker for Python 3.

![image 2018-07-30 10-34-36](https://user-images.githubusercontent.com/2379650/43403874-39f18e70-93e4-11e8-964e-35fcb18fdfe4.png)
